### PR TITLE
Repo normalization: Ignore trailing slash

### DIFF
--- a/naucse_hooks.py
+++ b/naucse_hooks.py
@@ -8,7 +8,7 @@ from typing import Iterator, Dict, Optional
 import requests
 import yaml
 import giturlparse
-from arca import Arca, CurrentEnvironmentBackend, RequirementsStrategy
+from arca import Arca, CurrentEnvironmentBackend
 from flask import Flask, request, jsonify, session, flash, redirect, url_for, render_template
 from flask_github import GitHub, GitHubError
 from flask_session import Session
@@ -31,7 +31,6 @@ app.logger.addHandler(handler)
 
 arca = Arca(backend=CurrentEnvironmentBackend(
     current_environment_requirements=None,
-    requirements_strategy=RequirementsStrategy.IGNORE
 ))
 github = GitHub(app)
 Session(app)

--- a/naucse_hooks.py
+++ b/naucse_hooks.py
@@ -91,6 +91,7 @@ def normalize_repo(repo) -> str:
     """
     repo = re.sub(r"^http[s]?://", "", repo)
     repo = re.sub(r".git$", "", repo)
+    repo = re.sub(r"/$", "", repo)
 
     return repo
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask
-git+https://github.com/mikicz/arca.git#egg=arca
+arca>=0.3.1
 pyyaml
 pytest
 pytest-cov

--- a/test_naucse_hooks.py
+++ b/test_naucse_hooks.py
@@ -40,6 +40,7 @@ def test_normalize_repo(denormalized, normalized):
     ("http://github.com/baxterthehacker/public-repo", "https://github.com/baxterthehacker/public-repo.git", True),
     ("https://github.com/baxterthehacker/public-repo.git", "https://github.com/baxthehacker/public-repo.git", False),
     ("https://github.com/baxterthehacker/public-repo.git", "https://github.com/baxterthehacker/public.git", False),
+    ("https://github.com/prusinsky/naucse.python.cz/", "https://github.com/prusinsky/naucse.python.cz.git", True),
 ])
 def test_same_repo(repo1, repo2, same):
     assert naucse_hooks.same_repo(repo1, repo2) == same

--- a/test_naucse_hooks.py
+++ b/test_naucse_hooks.py
@@ -59,7 +59,7 @@ def test_get_branch_from_ref(ref, branch):
 
 def test_get_last_commit_in_branch():
     # sha1 hash is 40 hexdec characters
-    assert len(naucse_hooks.get_last_commit_in_branch("https://github.com/mikicz/naucse-hooks.git", "master")) == 40
+    assert len(naucse_hooks.get_last_commit_in_branch("https://github.com/pyvec/naucse-hooks.git", "master")) == 40
 
 
 @pytest.fixture()


### PR DESCRIPTION
These repo URLs should be considered the same:
```
https://github.com/prusinsky/naucse.python.cz/
https://github.com/prusinsky/naucse.python.cz.git
```