### PR TITLE
Use Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-- '3.6'
+- '3.7'
 cache:
 - pip
 notifications:

--- a/naucse_hooks.py
+++ b/naucse_hooks.py
@@ -28,6 +28,7 @@ handler.setLevel(logging.INFO)
 handler.setFormatter(formatter)
 
 app.logger.addHandler(handler)
+app.logger.setLevel(logging.INFO)
 
 arca = Arca(backend=CurrentEnvironmentBackend(
     current_environment_requirements=None,


### PR DESCRIPTION
I'm re-installing my VPS from scratch (a different VPS which will then just be switched with the main one), so might as well upgrade hooks to Python 3.7

The logging update is included so the levels in the logger and handler match explicitly.