### PR TITLE
Raise error if POST request to Travis doesn't succeed

### DIFF
--- a/naucse_hooks.py
+++ b/naucse_hooks.py
@@ -125,7 +125,7 @@ def trigger_build(repo, branch):
             build.cancel()
 
     # unfortunately, TravisPy doesn't provide a method to trigger a build, so triggering manually:
-    requests.post(
+    response = requests.post(
         "https://api.travis-ci.org/repo/{}/requests".format(
             urllib.parse.quote_plus(app.config["TRAVIS_REPO_SLUG"])
         ),
@@ -140,6 +140,7 @@ def trigger_build(repo, branch):
             "Travis-API-Version": "3"
         }
     )
+    response.raise_for_status()
 
 
 def get_branch_from_ref(ref: str) -> Optional[str]:


### PR DESCRIPTION
I got a report that the rebuild wasn't scheduled even though the naucse-hooks said everything is OK.
Raising an error should help figure this out.