### PR TITLE
Fix flask-sessions compat with werkzeug>1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ travispy
 giturlparse
 raven[flask]
 github-flask
-Flask-Session
-
+# https://github.com/fengsp/flask-session/issues/112
+git+https://github.com/rayluo/flask-session@0.3.x#egg=flask-session


### PR DESCRIPTION
Currently tests aren't passing in CI because of https://github.com/fengsp/flask-session/issues/112. I ran tests locally with this fix, it ran fine, including @encukou's update, which I will deploy